### PR TITLE
16 send appointment reminder route

### DIFF
--- a/src/api/handlers/appointments/index.js
+++ b/src/api/handlers/appointments/index.js
@@ -1,7 +1,13 @@
 import postAppointments from "./postAppointments";
 import patchAppointments from "./patchAppointments";
 import getAppointments from "./getAppointments";
+import sendReminders from "./sendReminders";
 
-const appointments = { postAppointments, patchAppointments, getAppointments };
+const appointments = { 
+  postAppointments, 
+  patchAppointments, 
+  getAppointments,
+  sendReminders
+};
 
 export default appointments;

--- a/src/api/handlers/appointments/sendReminders.js
+++ b/src/api/handlers/appointments/sendReminders.js
@@ -19,7 +19,7 @@ export default async (req, res) => {
   } catch (error) {
     res.status(500).send({
       error,
-      message: `Could not retrieve appointments for ${daysFromNow(2)}`
+      message: `Could not retrieve appointments for ${daysFromNow(1)}`
     });
   }
 
@@ -74,7 +74,7 @@ export default async (req, res) => {
     .then((result) => res.status(200).send(result))
     .catch((error) => res.status(500).send({ 
         error,
-        message: `Could not send reminders for ${daysFromNow(7)}`
+        message: `Could not send reminders for ${daysFromNow(1)}`
       })
     );
 };

--- a/src/api/handlers/appointments/sendReminders.js
+++ b/src/api/handlers/appointments/sendReminders.js
@@ -1,0 +1,50 @@
+import moment from "moment";
+
+import { db } from "../../../../knex";
+import { sendMessage } from "../../../services/twilioClient";
+import TemplatesModel from "../../../models/templates";
+import LanguagesModel from "../../../models/languages";
+
+const daysFromNow = (interval) => {
+  return moment().add(interval, "d").format("YYYY-MM-DD hh:mm:ss");
+};
+
+export default async (req, res) => {
+  let appointments;
+  try {
+    appointments = await db("appointments")
+      .select("*")
+      .where("appointmentTime", ">=", daysFromNow(1))
+      .where("appointmentTime", "<", daysFromNow(2));
+  } catch (error) {
+    res.status(500).send({
+      error,
+      message: `Could not retrieve appointments for ${daysFromNow(2)}`
+    });
+  }
+
+  const appointmentsPromises = appointments.map(appointment => {
+    const language = LanguagesModel.getByLanguageString(appointment.patientLanguage);
+    // 1 is reminder template ID
+    const messageBody = TemplatesModel.generateMessage(1, language.id, appointment);
+
+    return new Promise((resolve) => {
+      sendMessage(appointment.patientPhoneNumber, messageBody)
+        .then(() => resolve(appointment))
+        // TODO: don't resolve this, send it to a log aggregator
+        .catch((error) => resolve({
+            error,
+            appointmentId: appointment.id
+          })
+        );
+    });
+  });
+
+  Promise.all(appointmentsPromises)
+    .then((result) => res.status(200).send(result))
+    .catch((error) => res.status(500).send({ 
+        error,
+        message: `Could not send reminders for ${daysFromNow(7)}`
+      })
+    );
+};

--- a/src/api/handlers/appointments/sendReminders.js
+++ b/src/api/handlers/appointments/sendReminders.js
@@ -24,17 +24,47 @@ export default async (req, res) => {
   }
 
   const appointmentsPromises = appointments.map(appointment => {
-    const language = LanguagesModel.getByLanguageString(appointment.patientLanguage);
-    // 1 is reminder template ID
+    const {
+      appointmentId,
+      patientLanguage,
+      patientPhoneNumber
+    } = appointment;
+  
+    const language = LanguagesModel.getByLanguageString(patientLanguage);
+    // 1 is reminder template ID, full templated needed for name in message record
+    const template = TemplatesModel.getById(1);
     const messageBody = TemplatesModel.generateMessage(1, language.id, appointment);
 
+    const message = {
+      appointmentId,
+      messageBody,
+      language: language.id,
+      templateName: template.templateName,
+      // UTC, will be the same for every message sent in a batch
+      timeSent: moment().format("YYYY-MM-DD HH:mm:ss")
+    };
+
     return new Promise((resolve) => {
-      sendMessage(appointment.patientPhoneNumber, messageBody)
-        .then(() => resolve(appointment))
+      sendMessage(patientPhoneNumber, messageBody)
+        .then(async () => {
+          let messageId;
+          try {
+            messageId = await db("messages").insert(message);
+          } catch (error) {
+            res.status(500).send({
+              error,
+              message: "Could not save message to database"
+            });
+          }
+          return resolve({
+            appointmentId,
+            messageId: messageId[0]
+          });
+        })
         // TODO: don't resolve this, create a log or send a notification to someone
         .catch((error) => resolve({
             error,
-            appointmentId: appointment.id
+            appointmentId
           })
         );
     });

--- a/src/api/handlers/appointments/sendReminders.js
+++ b/src/api/handlers/appointments/sendReminders.js
@@ -31,7 +31,7 @@ export default async (req, res) => {
     return new Promise((resolve) => {
       sendMessage(appointment.patientPhoneNumber, messageBody)
         .then(() => resolve(appointment))
-        // TODO: don't resolve this, send it to a log aggregator
+        // TODO: don't resolve this, create a log or send a notification to someone
         .catch((error) => resolve({
             error,
             appointmentId: appointment.id

--- a/src/api/handlers/appointments/sendReminders.js
+++ b/src/api/handlers/appointments/sendReminders.js
@@ -15,7 +15,7 @@ export default async (req, res) => {
     appointments = await db("appointments")
       .select("*")
       .where("appointmentTime", ">=", daysFromNow(1))
-      .where("appointmentTime", "<", daysFromNow(2));
+      .where("appointmentTime", "<", daysFromNow(3));
   } catch (error) {
     res.status(500).send({
       error,

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -7,7 +7,12 @@ import replies from "./handlers/replies";
 import languages from "./handlers/languages";
 import messageTemplates from "./handlers/templates";
 
-const { patchAppointments, postAppointments, getAppointments } = appointments;
+const { 
+  patchAppointments, 
+  postAppointments, 
+  getAppointments,
+  sendReminders
+} = appointments;
 const { getMessages, postMessages } = messages;
 const { postReplies } = replies;
 const { getLanguages } = languages;
@@ -15,43 +20,47 @@ const { getMessageTemplates } = messageTemplates;
 
 // eslint-disable-next-line no-unused-vars
 export default ({ config, db }) => {
-    let api = Router();
+  let api = Router();
 
-    // perhaps expose some API metadata at the root
-    api.get("/", (req, res) => {
-        res.json({ version });
-    });
+  // perhaps expose some API metadata at the root
+  api.get("/", (req, res) => {
+    res.json({ version });
+  });
 
-    // -- Appointments
+  // -- Appointments
 
-    api.get("/appointments", getAppointments);
-    api.post("/appointments", postAppointments);
-    api.patch("/appointments/:appointmentId", patchAppointments);
+  api.get("/appointments", getAppointments);
+  api.post("/appointments", postAppointments);
+  api.patch("/appointments/:appointmentId", patchAppointments);
 
-    // -- Messages
+  // -- Bulk messages
 
-    api.get("/appointments/:appointmentId/messages", getMessages);
-    api.post("/appointments/:appointmentId/messages", postMessages);
+  api.get("/appointments/sendReminders", sendReminders);
 
-    // -- Message Templates
+  // -- Messages
 
-    api.get("/templates", getMessageTemplates);
+  api.get("/appointments/:appointmentId/messages", getMessages);
+  api.post("/appointments/:appointmentId/messages", postMessages);
 
-    // -- Replies
+  // -- Message Templates
 
-    api.post("/reply/:phoneNumber", postReplies);
+  api.get("/templates", getMessageTemplates);
 
-    // -- Languages
+  // -- Replies
 
-    api.get("/languages", getLanguages);
+  api.post("/reply/:phoneNumber", postReplies);
 
-    // -- Ping
-    api.get("/ping", (req, res) => {
-        res.json("pong");
-    });
+  // -- Languages
 
-    api.post("/reply", postReplies);
-    api.get("/languages", getLanguages);
+  api.get("/languages", getLanguages);
 
-    return api;
+  // -- Ping
+  api.get("/ping", (req, res) => {
+      res.json("pong");
+  });
+
+  api.post("/reply", postReplies);
+  api.get("/languages", getLanguages);
+
+  return api;
 };

--- a/src/models/languages.js
+++ b/src/models/languages.js
@@ -2,17 +2,18 @@ const languages = [
   {
     id: "1",
     iso: "en",
-    name: "English",
+    name: "english",
     direction: "ltr"
   },
   {
     id: "2",
     iso: "ar",
-    name: "Arabic",
+    name: "arabic",
     direction: "rtl"
   }
 ];
 
 export default {
-    getAll: () => (languages)
+  getAll: () => (languages),
+  getByLanguageString: (language) => languages.find((obj) => obj.name === language)
 };


### PR DESCRIPTION
endpoint for scheduled lambda to hit.

currently set to remind about appointments scheduled for the next day and day of. It will use the same template, so patients will get the same text at 7am the day before and day of their appointment. 

returns appointment objects for all successful messages and twilio error message for failed messages.

the resolve on line 35 is annoying, so let me know if you have any better ideas.

language templates updated to be lowercase (to match enum values in DB).

only important line in `/api/index` is 38, the rest is just fixing indentation and importing the new handler.