### PR TITLE
send reminder message immediately when appointment is created

### DIFF
--- a/src/api/handlers/appointments/postAppointments.js
+++ b/src/api/handlers/appointments/postAppointments.js
@@ -39,7 +39,8 @@ export default async (req, res) => {
     return;
   }
 
-  const language = LanguagesModel.getByLanguageString(patientLanguage);
+  // const language = LanguagesModel.getByLanguageString(patientLanguage);
+  const language = 1;
   const template = TemplatesModel.getById(1);
   const messageBody = TemplatesModel.generateMessage(1, language.id, appointment);
 
@@ -52,29 +53,25 @@ export default async (req, res) => {
     timeSent: moment().format("YYYY-MM-DD HH:mm:ss")
   };
 
-  sendMessage(patientPhoneNumber, messageBody)
-    .then(async () => {
-      let messageId;
-      try {
-        messageId = await db("messages").insert(message);
-      } catch (error) {
-        res.status(500).send({
-          error,
-          message: "Could not save message to database"
-        });
-        return;
-      }
-      res.status(200).send({
-        insertedAppointmentId,
-        messageId: messageId[0]
-      });
-      return;
-    })
+  await sendMessage(patientPhoneNumber, messageBody)
     .catch((error) => {
-      res.status(500).send({
-        error,
-        insertedAppointmentId
-      })
+      res.status(500).send({ error, message: "Failed to send appointment reminder"});
       return;
     });
+
+  let messageId;
+  try {
+    messageId = await db("messages").insert(message);
+  } catch (error) {
+    res.status(500).send({
+      error,
+      message: "Could not save message to database"
+    });
+    return;
+  }
+  res.status(200).send({
+    insertedAppointmentId,
+    messageId: messageId[0]
+  });
+  return;
 };

--- a/src/api/handlers/appointments/postAppointments.js
+++ b/src/api/handlers/appointments/postAppointments.js
@@ -1,6 +1,10 @@
+import moment from "moment";
 import { db } from "../../../../knex";
+import TemplatesModel from "../../../models/templates";
+import LanguagesModel from "../../../models/languages";
+import { sendMessage } from "../../../services/twilioClient";
 
-export default (req, res) => {
+export default async (req, res) => {
   const {
     date,
     location,
@@ -24,9 +28,52 @@ export default (req, res) => {
     appointmentIsConfirmed: false
   };
 
-  db("appointments")
-  .insert(appointment)
-  .then(result => {
-    res.status(201).send(result);
-  });
+  let insertedAppointmentId;
+  try {
+    insertedAppointmentId = await db("appointments").insert(appointment);
+  } catch (error) {
+    res.status(500).send({
+      error,
+      message: `Could not insert appointment for ${patientPhoneNumber}`
+    });
+    return;
+  }
+
+  const language = LanguagesModel.getByLanguageString(patientLanguage);
+  const template = TemplatesModel.getById(1);
+  const messageBody = TemplatesModel.generateMessage(1, language.id, appointment);
+
+  const message = {
+    appointmentId: insertedAppointmentId,
+    messageBody,
+    language: language.id,
+    templateName: template.templateName,
+    // UTC
+    timeSent: moment().format("YYYY-MM-DD HH:mm:ss")
+  };
+
+  sendMessage(patientPhoneNumber, messageBody)
+    .then(async () => {
+      let messageId;
+      try {
+        messageId = await db("messages").insert(message);
+      } catch (error) {
+        res.status(500).send({
+          error,
+          message: "Could not save message to database"
+        });
+      }
+      res.status(200).send({
+        insertedAppointmentId,
+        messageId: messageId[0]
+      });
+      return;
+    })
+    .catch((error) => {
+      res.status(500).send({
+        error,
+        insertedAppointmentId
+      })
+      return;
+    });
 };

--- a/src/api/handlers/appointments/postAppointments.js
+++ b/src/api/handlers/appointments/postAppointments.js
@@ -62,6 +62,7 @@ export default async (req, res) => {
           error,
           message: "Could not save message to database"
         });
+        return;
       }
       res.status(200).send({
         insertedAppointmentId,

--- a/src/api/handlers/appointments/postAppointments.js
+++ b/src/api/handlers/appointments/postAppointments.js
@@ -52,11 +52,12 @@ export default async (req, res) => {
     timeSent: moment().format("YYYY-MM-DD HH:mm:ss")
   };
 
-  await sendMessage(patientPhoneNumber, messageBody)
-    .catch((error) => {
-      res.status(500).send({ error, message: "Failed to send appointment reminder"});
-      return;
-    });
+  try {
+    await sendMessage(patientPhoneNumber, messageBody);
+  } catch (error) {
+    res.status(500).send({ error, message: "Failed to send appointment reminder"});
+    return;
+  }
 
   let messageId;
   try {
@@ -68,6 +69,7 @@ export default async (req, res) => {
     });
     return;
   }
+
   res.status(200).send({
     insertedAppointmentId,
     messageId: messageId[0]

--- a/src/api/handlers/appointments/postAppointments.js
+++ b/src/api/handlers/appointments/postAppointments.js
@@ -39,8 +39,7 @@ export default async (req, res) => {
     return;
   }
 
-  // const language = LanguagesModel.getByLanguageString(patientLanguage);
-  const language = 1;
+  const language = LanguagesModel.getByLanguageString(patientLanguage);
   const template = TemplatesModel.getById(1);
   const messageBody = TemplatesModel.generateMessage(1, language.id, appointment);
 


### PR DESCRIPTION
Line 42 requires PR #19 .

It's probably time to think about breaking the "send message by appointment" stuff into its own module, since it now exists in some form here, in the sendReminders handler and in the POST message handler.

The template currently will be the same for all 3 (appt creation, day before, day of) reminder texts.